### PR TITLE
fix: version template for zarf action

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -39,13 +39,20 @@
     },
     {
       "depNameTemplate": "defenseunicorns/zarf",
-      "fileMatch": ["\\.*\\.ya?ml$","README\\.md"],
+      "fileMatch": ["README\\.md"],
       "matchStrings": [
-        "- Zarf: (?<currentValue>.*)",
-        "# renovate: datasource=github-tags depName=defenseunicorns/zarf versioning=(?<versioning>.*?)\n.*?(version:) (?<currentValue>.*)"
+        "- Zarf: (?<currentValue>.*)"
       ],
       "datasourceTemplate": "github-tags",
       "extractVersionTemplate": "^v(?<version>.*)$"
+    },
+    {
+      "depNameTemplate": "defenseunicorns/zarf",
+      "fileMatch": ["\\.*\\.ya?ml$"],
+      "matchStrings": [
+        "# renovate: datasource=github-tags depName=defenseunicorns/zarf versioning=(?<versioning>.*?)\n.*?(version:) (?<currentValue>.*)"
+      ],
+      "datasourceTemplate": "github-tags",
     }
   ],
   "packageRules": [


### PR DESCRIPTION
`v` is getting stripped off incorrectly in https://github.com/defenseunicorns/uds-common-tasks/pull/7/files