### PR TITLE
fix: prevent publish vars from being blown away

### DIFF
--- a/tasks/publish.yaml
+++ b/tasks/publish.yaml
@@ -2,12 +2,6 @@ variables:
   - name: TARGET_REPO
     default: oci://ghcr.io/defenseunicorns/packages/uds
 
-  - name: VERSION
-    description: "The version of the package to build, should be version controlled by release-please"
-
-  - name: FLAVOR
-    default: "upstream"
-
 tasks:
   - name: package
     description: Publish the packages


### PR DESCRIPTION
Remove variables in publish so they can be overridden in other task files.