### PR TITLE
chore: switch to uds zarf

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -4,13 +4,6 @@ description: "UDS Environment Setup"
 runs:
   using: "composite"
   steps:
-    - name: Install Zarf
-      uses: defenseunicorns/setup-zarf@main
-      with:
-        # renovate: datasource=github-tags depName=defenseunicorns/zarf versioning=semver
-        version: v0.32.2
-        download-init-package: false
-
     - name: Install k3d
       shell: bash
       run: curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | TAG=v5.6.0 bash

--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@ Pinning to a specific tag of these tasks (rather than `main`) with renovate watc
 ## Supported Tool Versions
 
 - UDS CLI: 0.8.1
-- Zarf: 0.32.2
 - UDS Core: 0.10.0
+
+NOTE: Zarf is not required for these tasks, the vendored zarf (`uds zarf`) included with UDS CLI is used instead to prevent version issues.
 
 ## Task Files
 

--- a/renovate.json
+++ b/renovate.json
@@ -34,29 +34,12 @@
       ],
       "datasourceTemplate": "github-tags",
       "extractVersionTemplate": "^v(?<version>.*)$"
-    },
-    {
-      "depNameTemplate": "defenseunicorns/zarf",
-      "fileMatch": ["README\\.md"],
-      "matchStrings": [
-        "- Zarf: (?<currentValue>.*)"
-      ],
-      "datasourceTemplate": "github-tags",
-      "extractVersionTemplate": "^v(?<version>.*)$"
-    },
-    {
-      "depNameTemplate": "defenseunicorns/zarf",
-      "fileMatch": ["\\.*\\.ya?ml$"],
-      "matchStrings": [
-        "# renovate: datasource=github-tags depName=defenseunicorns/zarf versioning=(?<versioning>.*?)\n.*?(version:) (?<currentValue>.*)"
-      ],
-      "datasourceTemplate": "github-tags"
     }
   ],
   "packageRules": [
     { 
       "matchFileNames": [".github/**"],
-      "excludePackageNames": ["defenseunicorns/zarf","defenseunicorns/uds-cli"],
+      "excludePackageNames": ["defenseunicorns/uds-cli"],
       "groupName": "githubactions",
       "commitMessageTopic": "githubactions",
       "pinDigests": true

--- a/tasks/create.yaml
+++ b/tasks/create.yaml
@@ -6,7 +6,7 @@ tasks:
   - name: package
     description: Create the UDS Zarf Package
     actions:
-      - cmd: zarf package create --confirm --no-progress --architecture=${ZARF_ARCHITECTURE} --flavor ${FLAVOR}
+      - cmd: uds zarf package create --confirm --no-progress --architecture=${ZARF_ARCHITECTURE} --flavor ${FLAVOR}
 
   - name: test-bundle
     description: Create the test UDS Bundle

--- a/tasks/deploy.yaml
+++ b/tasks/deploy.yaml
@@ -2,7 +2,7 @@ tasks:
   - name: package
     actions:
       - description: Deploy the UDS Zarf Package
-        cmd: zarf package deploy zarf-package-*-${UDS_ARCH}-*.tar.zst --confirm --no-progress
+        cmd: uds zarf package deploy zarf-package-*-${UDS_ARCH}-*.tar.zst --confirm --no-progress
 
   - name: test-bundle
     actions:

--- a/tasks/publish.yaml
+++ b/tasks/publish.yaml
@@ -9,8 +9,8 @@ tasks:
       - description: Publish the packages
         cmd: |
           set -e
-          zarf package publish zarf-package-*-amd64-${VERSION}.tar.zst ${TARGET_REPO}
+          uds zarf package publish zarf-package-*-amd64-${VERSION}.tar.zst ${TARGET_REPO}
           if [ ${FLAVOR} != "registry1" ]; then
-           zarf package publish zarf-package-*-arm64-${VERSION}.tar.zst ${TARGET_REPO}
+            uds zarf package publish zarf-package-*-arm64-${VERSION}.tar.zst ${TARGET_REPO}
           fi
           set +e


### PR DESCRIPTION
Removes need for zarf on its own, switches to the incredible `uds zarf` instead.